### PR TITLE
Fix 'sticky' block collisions

### DIFF
--- a/src/gameloop.c
+++ b/src/gameloop.c
@@ -316,7 +316,7 @@ int gameLoop (
             playerMovement.y * ((m + 1) % 3 / 2);
           f19 =
             player.pos.z +
-            playerMovement.z * ((m + 2) % 3 / 2);
+            playerMovement.z * ((m + 3) % 3 / 2);
           
           for (i12 = 0; i12 < 12; i12++) {
             i13 = (int)(f16 + (i12 >> 0 & 0x1) * 0.6 - 0.3)  - 64;
@@ -344,8 +344,9 @@ int gameLoop (
           player.pos.x = f16;
           player.pos.y = f17;
           player.pos.z = f19;
+          
+          label208:;
         }
-        label208:;
       }
       
       i6 = 0;


### PR DESCRIPTION
Fixes the issue of players being able to stick to walls and not being able to move to the side when running into a block.

The cause:
From what I managed to understand, the 'm' variable is essentially the axis along which the collisions are being checked, 
0 -> x
1 -> y
2 -> z, 
during the check for each axis, the multiplier for the velocity and thus the players future position is moved depending on the value of m.

If we write out the values by which the speed is multiplied (excluding the / 2) we get the following sequence:

x -> 2, 0, 1
y -> 1, 2, 0
z -> 2, 0, 1

Means the checks for whether we collide along the x or the z axis are the same, thus blocking players movement to the side when running into a block.

Adding a 1 moves the sequence and fixes the issue: 
z -> 0, 1, 2

-------------------------------------------------------

The issue of players being able to stick to walls was caused by the fact that we essentially skip the check along the other axis due to the label208's location