### PR TITLE
Almost completely fix the rendering bugs in the negatives

### DIFF
--- a/src/gameloop.h
+++ b/src/gameloop.h
@@ -4,8 +4,6 @@
 #include "terrain.h"
 #include "main.h"
 #include "player.h"
-
-#define PLAYER_POSITION_OFFSET 128
  
 int  gameLoop            (Inputs *inputs, SDL_Renderer *renderer);
 void gameLoop_resetGame  ();


### PR DESCRIPTION
The issue was being caused by the incorrect usage of integer casts. Basically, a negative float with a value like -1.2 would be turned into -1, while the result needed in our case is -2, which, thankfully, floor() returns.

This pull request also removes the player offset entirely, as its not needed anymore. 

The only visual glitch remaining is the minor pixel dithering on the border between the negative and positive coordinates.
![Screenshot](https://github.com/sashakoshka/m4kc/assets/62417300/31cdb6d9-acce-4a0c-8f79-dd116ca090bb)
